### PR TITLE
Replaced most of the packages with Ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,51 +17,16 @@ repos:
     rev: 1.7.6
     hooks:
       - id: bandit
-  - repo: https://github.com/psf/black
-    rev: 23.11.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.4
     hooks:
-      - id: black
-        language_version: python3.12
-        args:
-          - --line-length=128
-      - id: black-jupyter
-        language_version: python3.12
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.0
-    hooks:
-      - id: isort
-        args: [ "--profile", "black" ]
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.1.0
-    hooks:
-      - id: flake8
-        args:
-          - "--max-line-length=128"
-        additional_dependencies:
-          - flake8-bugbear
-          - flake8-comprehensions
-          - flake8-simplify
+      - id: ruff
+        args: [ --fix ]
+      - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.7.1
     hooks:
       - id: mypy
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
-    hooks:
-      - id: pyupgrade
-        args: [--py311-plus]
-  - repo: https://github.com/asottile/yesqa
-    rev: v1.5.0
-    hooks:
-      - id: yesqa
-        additional_dependencies:
-          - flake8-bugbear==22.8.23
-          - flake8-comprehensions==3.10.0
-          - flake8-docstrings==1.6.0
-  - repo: https://github.com/hadialqattan/pycln
-    rev: v2.4.0
-    hooks:
-      - id: pycln
   - repo: https://github.com/commitizen-tools/commitizen
     rev: v3.13.0
     hooks:


### PR DESCRIPTION
[ruff](https://docs.astral.sh/ruff/) is a modern replacement (mainly) for all the deleted packages and is much faster -- something which is critical for pre-commits.

Making this PR because "precommit heaven" was one of the first articles I read about pre-commits from and it would be helpful to update this with the most modern tooling so developers save time and start off on the right foot.

I'd also recommend updating the versions.

Thank you for posting!